### PR TITLE
Make baseurl interpretation consistent

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -6,7 +6,7 @@
       <h2 class="subtitle is-4">
         Page not found
       </h2>
-      <a class="button" href="{{ .Site.BaseURL }}">Home Page</a>
+      <a class="button" href="{{ .Site.BaseURL }}/">Home Page</a>
     </div>
   </div>
 </section>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -2,7 +2,7 @@
   <div class="container">
     <nav class="nav">
       <div class="nav-left">
-        <a class="nav-item" href="{{ .Site.BaseURL }}"><h1 class="title is-4">{{ .Site.Title }}</h1></a>
+        <a class="nav-item" href="{{ .Site.BaseURL }}/"><h1 class="title is-4">{{ .Site.Title }}</h1></a>
       </div>
       <div class="nav-right">
         <nav class="nav-item level is-mobile">


### PR DESCRIPTION
Follow each `{{ .Site.BaseURL }}` with a single `/`. This is consistent
with the interpretation in layouts/partials/header.html and fixes an
issue where users cannot host a hugo site from the root directory
without specifying the fqdn.

Now it is possible to do so by setting the baseurl to the empty string.
It would be more elegant to normalise BaseURL usage to expect a string
that ends in a slash, but that would break any existing setup where
BaseURL does not end in a slash.